### PR TITLE
Documentation update

### DIFF
--- a/DAPS/register_connector.sh
+++ b/DAPS/register_connector.sh
@@ -11,14 +11,6 @@ CLIENT_SECURITY_PROFILE=$2
 [ -z "$CLIENT_SECURITY_PROFILE" ] && CLIENT_SECURITY_PROFILE="idsc:BASE_SECURITY_PROFILE"
 
 CLIENT_CERT="keys/$CLIENT_NAME.cert"
-if [ -n "$3" ]; then
-    [ ! -f "$3" ] && (echo "Cert not found"; exit 1)
-    cert_format="DER"
-    openssl x509 -noout -in "$3" 2>/dev/null && cert_format="PEM"
-    openssl x509 -inform "$cert_format" -in "$3" -text > "$CLIENT_CERT"
-else
-    openssl pkcs12 -export -in "$CLIENT_CERT" -inkey "keys/${CLIENT_NAME}.key" -out "keys/${CLIENT_NAME}.p12"
-fi
 
 SKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Subject Key Identifier" | tail -n 1 | tr -d ' ')"
 AKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Authority Key Identifier" | tail -n 1 | tr -d ' ')"

--- a/InstallationGuide.md
+++ b/InstallationGuide.md
@@ -1,5 +1,16 @@
 # IDSA Reference Testbed Installation (CA-DAPS-DSC-MDB)
 
+## Index
+- [Execution modes](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#execution-modes)
+    - [Preconfigured testbed](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#target-view-preconfigured-testbed)
+    - [Manual testbed set up](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#target-view-manual-testbed-set-up)
+- [Target View: Preconfigured testbed](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#target-view-preconfigured-testbed)
+- [Target View: Manual testbed set up](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#target-view-manual-testbed-set-up)
+    - [Certificate Authority](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#certificate-authority)
+    - [DAPS](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#daps)
+    - [Dataspace Connector](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#dataspace-connector)
+    - [Metadata Broker](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#metadata-broker)
+
 The installation and configuration process is explained below for each of the components. To further support this document, the links to the official installation guides will be linked.
 
 ## Execution modes

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ IDS Testbed is a setup with Open Source IDS components which can be used to ve
 
 1. Git clone this repository to your local machine and go into the directory (usually ```cd IDS-testbed```) 
 
-2. Make sure you have installed Docker and Docker Compose on your machine. Run ```docker compose up -d``` or ```docker-compose up -d``` to start the Testbed. 
+2. Make sure you have correctly installed all the [setting up requirements](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#target-view-preconfigured-testbed). Run ```docker compose up -d``` to start the Testbed and deploy all the components.
    
-3. Run the [Postman collection](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/TestbedPreconfiguration.postman_collection.json) to start the tests. Current available components for testing are: Dataspace connector, DAPS, CA, Metadata Broker.
+3. Run the [Postman collection](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/TestbedPreconfiguration.postman_collection.json) to start the tests. There is a guide with the installation and use of Postman which is located [here](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/PreparingPreconfiguredSetup.md#guide-for-preparing-and-validating-the-preconfigured-setup). Current available components for testing are: CA, DAPS, Dataspace connector, Metadata Broker.
 
 4. Test the compatibility of your own developed component following the steps of the [Testbed User Guide](./TestbedUserGuide.md).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Used versions of the IDS-testbed components:
 - Certificate Authority (CA)
 - Dynamic Attribute Provisioning Service (DAPS) v1.6.0
 - Dataspace Connector (DSC) v7.1.0
-- MetadataBroker (MDB) v4.2.8
+- MetadataBroker (MDB) v5.0.0
 
 ## Roadmap
 ### Version 2.0 of the test bed

--- a/TestbedUserGuide.md
+++ b/TestbedUserGuide.md
@@ -3,7 +3,7 @@
 This user guide is meant to explain to each testbed user what they should do with the testbed in order to assess the compatibility of their own developed component.
 
 ## 1. Download and Install the Testbed
-Follow the instructions in the [installation and configuration guide](./README.md) to install and configure the testbed as required. Utilize the preconfigured setup described as basis for the this user guide.
+Follow the instructions in the [installation and configuration guide](./InstallationGuide.md) to install and configure the testbed as required. Utilize the preconfigured setup described as basis for this user guide.
 
 ## 2. Integrating your Connector into the Ecosystem
 ### 2.1. Generate a Certificate for your Connector
@@ -18,15 +18,13 @@ Ensure that your connector always utilizes this IDS certificate to prove their i
 
 ### 2.2. Configure your Connector
 * Configure your connector to use the common Root CA (cert). For the preconfigured setup, the file to be utilized is [CertificateAuthority/data/ca/ReferenceTestbedCA.crt](./CertificateAuthority/data/ca/ReferenceTestbedCA.crt)
-* Configure your connector to use the DAPS available under http://localhost:4567 (endpoints: /token, /.well-known/jwks.json)
+* Configure your connector to use the DAPS available under https://localhost:443 (endpoints: /token, /.well-known/jwks.json)
 * Provide a self-description for your connector
 
 ## 3. Interacting with the DAPS
 ### 3.1. Register your connector at the DAPS
-Register your connector following  
-a) the instructions provided here:
-https://github.com/International-Data-Spaces-Association/omejdn-daps#registering-connectors  
-or b) the manual steps described below:
+- Register your connector following the instructions provided [here](https://github.com/International-Data-Spaces-Association/IDS-testbed/blob/master/InstallationGuide.md#adding-the-clients-to-the-daps).
+- Or use the manual steps described below:
 1. Convert your connector certificate {common name}.crt from step 2.1 into the format required by the DAPS:
 ```
 ## .crt + .key -> .p12
@@ -34,9 +32,9 @@ openssl pkcs12 -export -out {common name}.p12 -inkey {common name}.key -in {comm
 ## .p12 -> .cert
 openssl pkcs12 -in {common name}.p12 -out {common name}.cert -nokeys -nodes -passin pass:password
 ```
-2. Add the certificate {common name}.cert to the OmejdnDAPS/keys directory
-3. Add your client information identified by the unique identifier (client_id) in the OmejdnDAPS/config/clients.yml file following the given examples in this file.
-The provided script [OmejdnDAPS/keys/extensions.sh](./OmejdnDAPS/keys/extensions.sh) can extract the unique identifier from the certificate to help the users who are not familiar with AKI/SKI extensions.
+2. Add the certificate {common name}.cert to the DAPS/keys directory
+3. Add your client information identified by the unique identifier (client_id) in the DAPS/config/clients.yml file following the given examples in this file.
+The provided script [DAPS/register_connector.sh](./DAPS/register_connector.sh) can extract the unique identifier from the certificate to help the users who are not familiar with AKI/SKI extensions. This script adds the specified certificate to the DAPS's list of clients.
 
 ### 3.2. Request your DAT
 * Use your connector to request a DAT from the DAPS
@@ -56,58 +54,69 @@ Request the Self-Description from Connector A using those of the following proto
 Validate that you receive the following self-description:
 ```json
 {
-  "@context" : {
-    "ids" : "https://w3id.org/idsa/core/",
-    "idsc" : "https://w3id.org/idsa/code/"
-  },
-  "@type" : "ids:BaseConnector",
-  "@id" : "https://connector_A",
-  "ids:description" : [ {
-    "@value" : "IDS Connector A with static example resources",
-    "@type" : "http://www.w3.org/2001/XMLSchema#string"
-  } ],
-  "ids:version" : "6.2.0",
-  "ids:title" : [ {
-    "@value" : "Dataspace Connector",
-    "@type" : "http://www.w3.org/2001/XMLSchema#string"
-  } ],
-  "ids:hasEndpoint" : [ ],
-  "ids:hasDefaultEndpoint" : {
-    "@type" : "ids:ConnectorEndpoint",
-    "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
-    "ids:accessURL" : {
-      "@id" : "https://connectora:8080/api/ids/data"
+    "@context": {
+        "ids": "https://w3id.org/idsa/core/",
+        "idsc": "https://w3id.org/idsa/code/"
     },
-    "ids:endpointDocumentation" : [ ],
-    "ids:endpointInformation" : [ ]
-  },
-  "ids:resourceCatalog" : [ {
-    "@type" : "ids:ResourceCatalog",
-    "@id" : "https://localhost:8080/api/catalogs/2cd59c94-54e4-4979-9842-36ee45dd354f",
-    "ids:offeredResource" : [ ],
-    "ids:requestedResource" : [ ]
-  }],
-  "ids:hasAgent" : [ ],
-  "ids:securityProfile" : {
-    "@id" : "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE"
-  },
-  "ids:extendedGuarantee" : [ ],
-  "ids:maintainer" : {
-    "@id" : "https://www.isst.fraunhofer.de/"
-  },
-  "ids:curator" : {
-    "@id" : "https://www.isst.fraunhofer.de/"
-  },
-  "ids:inboundModelVersion" : [ "4.2.0", "4.1.2", "4.0.0", "4.1.0" ],
-  "ids:outboundModelVersion" : "4.2.0",
-  "ids:publicKey" : {
-    "@type" : "ids:PublicKey",
-    "@id" : "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
-    "ids:keyType" : {
-      "@id" : "https://w3id.org/idsa/code/RSA"
+    "@type": "ids:BaseConnector",
+    "@id": "https://connector_A",
+    "ids:publicKey": {
+        "@type": "ids:PublicKey",
+        "@id": "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
+        "ids:keyType": {
+            "@id": "https://w3id.org/idsa/code/RSA"
+        },
+        "ids:keyValue": "VFVsSlFrbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGUk9FRk5TVWxDUTJkTFEwRlJSVUYxZHpadFJuSmtabXhZV2xSS1owWlBRVFZ6YlVSWVF6QTVVMjF3U2xkdlIzQjVSVkphVGtWNU16RndTMlJ6VWtkb1ZHbHdVakkzYWpscGNtMXRjV2xvZGpkblNXZDZRMjU0Tm10SlVrNUhTVEoxTUc5R1VUVkdaM1pQTVhoNFozcGphV2hrY0VZd1EyaGxUMlk1U1U1bmFYTlFhM0UxYUdvNFFXVXZSRmxZYTNacWFGRTJZelpoYXk5YVdXWnFNRTV3Y1hsRlVHTktOVTFNVW0xWlIyVjRUV0ZOV20xVVluRkVTblpLYkRWS1J6TXJZa1V6V1dFeU1XaFVXbGxQZUdsVGFXTndaa1puU2pNd2EyNDFZVlZKUVhSa01EVkpXbmszZWpGelJHbFdUSFJVV0d4TVptVXZXbEZETkhCdWFrWjBjeXQwWXpFeWMxZzVhV2hKYlc1RGEyUXdWM1o2TTBOVVdtOTVRbE56WXpGVVpFSnJZamx0TUVNMWRIWm5NR1pSVURSUlowWXZla2d5VVc5YWJtNXlTVFV5ZFVGYU9FMXZiVmQwV1RKc2RETkVNR3RyY0ZJMk9YQm1Wa1JLTjNremRrNHZaWGRKUkVGUlFVST0="
     },
-    "ids:keyValue" : "VFVsSlFrbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGUk9FRk5TVWxDUTJkTFEwRlJSVUYxZHpadFJuSmtabXhZV2xSS1owWlBRVFZ6YlVSWVF6QTVVMjF3U2xkdlIzQjVSVkphVGtWNU16RndTMlJ6VWtkb1ZHbHdVakkzYWpscGNtMXRjV2xvZGpkblNXZDZRMjU0Tm10SlVrNUhTVEoxTUc5R1VUVkdaM1pQTVhoNFozcGphV2hrY0VZd1EyaGxUMlk1U1U1bmFYTlFhM0UxYUdvNFFXVXZSRmxZYTNacWFGRTJZelpoYXk5YVdXWnFNRTV3Y1hsRlVHTktOVTFNVW0xWlIyVjRUV0ZOV20xVVluRkVTblpLYkRWS1J6TXJZa1V6V1dFeU1XaFVXbGxQZUdsVGFXTndaa1puU2pNd2EyNDFZVlZKUVhSa01EVkpXbmszZWpGelJHbFdUSFJVV0d4TVptVXZXbEZETkhCdWFrWjBjeXQwWXpFeWMxZzVhV2hKYlc1RGEyUXdWM1o2TTBOVVdtOTVRbE56WXpGVVpFSnJZamx0TUVNMWRIWm5NR1pSVURSUlowWXZla2d5VVc5YWJtNXlTVFV5ZFVGYU9FMXZiVmQwV1RKc2RETkVNR3RyY0ZJMk9YQm1Wa1JLTjNremRrNHZaWGRKUkVGUlFVST0="
-  }
+    "ids:version": "7.1.0",
+    "ids:description": [
+        {
+            "@value": "IDS Connector A with static example resources",
+            "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+    ],
+    "ids:resourceCatalog": [
+        {
+            "@type": "ids:ResourceCatalog",
+            "@id": "https://connectora:8080/api/catalogs/eb72752d-23ed-4ff8-b679-bd4c4b950b97"
+        }
+    ],
+    "ids:securityProfile": {
+        "@id": "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE"
+    },
+    "ids:maintainer": {
+        "@id": "https://sovity.de/"
+    },
+    "ids:curator": {
+        "@id": "https://sovity.de/"
+    },
+    "ids:inboundModelVersion": [
+        "4.2.6",
+        "4.2.7",
+        "4.2.0",
+        "4.1.2",
+        "4.2.1",
+        "4.0.0",
+        "4.1.0",
+        "4.2.4",
+        "4.2.5",
+        "4.2.2",
+        "4.2.3"
+    ],
+    "ids:outboundModelVersion": "4.2.7",
+    "ids:title": [
+        {
+            "@value": "Dataspace Connector",
+            "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+    ],
+    "ids:hasDefaultEndpoint": {
+        "@type": "ids:ConnectorEndpoint",
+        "@id": "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
+        "ids:accessURL": {
+            "@id": "https://connectora:8080/api/ids/data"
+        }
+    }
 }
 ```
 
@@ -122,68 +131,77 @@ Request the Self-Description from Connector B using those of the following proto
 Validate that you receive the following self-description:
 ```json
 {
-  "@context" : {
-    "ids" : "https://w3id.org/idsa/core/",
-    "idsc" : "https://w3id.org/idsa/code/"
-  },
-  "@type" : "ids:BaseConnector",
-  "@id" : "https://connector_B",
-  "ids:version" : "6.2.0",
-  "ids:description" : [ {
-    "@value" : "IDS Connector B with static example resources",
-    "@type" : "http://www.w3.org/2001/XMLSchema#string"
-  } ],
-  "ids:resourceCatalog" : [ ],
-  "ids:hasAgent" : [ ],
-  "ids:securityProfile" : {
-    "@id" : "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE"
-  },
-  "ids:extendedGuarantee" : [ ],
-  "ids:maintainer" : {
-    "@id" : "https://www.isst.fraunhofer.de/"
-  },
-  "ids:curator" : {
-    "@id" : "https://www.isst.fraunhofer.de/"
-  },
-  "ids:inboundModelVersion" : [ "4.2.0", "4.1.2", "4.0.0", "4.1.0" ],
-  "ids:outboundModelVersion" : "4.2.0",
-  "ids:publicKey" : {
-    "@type" : "ids:PublicKey",
-    "@id" : "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
-    "ids:keyType" : {
-      "@id" : "https://w3id.org/idsa/code/RSA"
+    "@context": {
+        "ids": "https://w3id.org/idsa/core/",
+        "idsc": "https://w3id.org/idsa/code/"
     },
-    "ids:keyValue" : "VFVsSlFrbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGUk9FRk5TVWxDUTJkTFEwRlJSVUYxZHpadFJuSmtabXhZV2xSS1owWlBRVFZ6YlVSWVF6QTVVMjF3U2xkdlIzQjVSVkphVGtWNU16RndTMlJ6VWtkb1ZHbHdVakkzYWpscGNtMXRjV2xvZGpkblNXZDZRMjU0Tm10SlVrNUhTVEoxTUc5R1VUVkdaM1pQTVhoNFozcGphV2hrY0VZd1EyaGxUMlk1U1U1bmFYTlFhM0UxYUdvNFFXVXZSRmxZYTNacWFGRTJZelpoYXk5YVdXWnFNRTV3Y1hsRlVHTktOVTFNVW0xWlIyVjRUV0ZOV20xVVluRkVTblpLYkRWS1J6TXJZa1V6V1dFeU1XaFVXbGxQZUdsVGFXTndaa1puU2pNd2EyNDFZVlZKUVhSa01EVkpXbmszZWpGelJHbFdUSFJVV0d4TVptVXZXbEZETkhCdWFrWjBjeXQwWXpFeWMxZzVhV2hKYlc1RGEyUXdWM1o2TTBOVVdtOTVRbE56WXpGVVpFSnJZamx0TUVNMWRIWm5NR1pSVURSUlowWXZla2d5VVc5YWJtNXlTVFV5ZFVGYU9FMXZiVmQwV1RKc2RETkVNR3RyY0ZJMk9YQm1Wa1JLTjNremRrNHZaWGRKUkVGUlFVST0="
-  },
-  "ids:title" : [ {
-    "@value" : "Dataspace Connector",
-    "@type" : "http://www.w3.org/2001/XMLSchema#string"
-  } ],
-  "ids:hasDefaultEndpoint" : {
-    "@type" : "ids:ConnectorEndpoint",
-    "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
-    "ids:accessURL" : {
-      "@id" : "https://connectorb:8081/api/ids/data"
+    "@type": "ids:BaseConnector",
+    "@id": "https://connector_B",
+    "ids:publicKey": {
+        "@type": "ids:PublicKey",
+        "@id": "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
+        "ids:keyType": {
+            "@id": "https://w3id.org/idsa/code/RSA"
+        },
+        "ids:keyValue": "VFVsSlFrbHFRVTVDWjJ0eGFHdHBSemwzTUVKQlVVVkdRVUZQUTBGUk9FRk5TVWxDUTJkTFEwRlJSVUYxZHpadFJuSmtabXhZV2xSS1owWlBRVFZ6YlVSWVF6QTVVMjF3U2xkdlIzQjVSVkphVGtWNU16RndTMlJ6VWtkb1ZHbHdVakkzYWpscGNtMXRjV2xvZGpkblNXZDZRMjU0Tm10SlVrNUhTVEoxTUc5R1VUVkdaM1pQTVhoNFozcGphV2hrY0VZd1EyaGxUMlk1U1U1bmFYTlFhM0UxYUdvNFFXVXZSRmxZYTNacWFGRTJZelpoYXk5YVdXWnFNRTV3Y1hsRlVHTktOVTFNVW0xWlIyVjRUV0ZOV20xVVluRkVTblpLYkRWS1J6TXJZa1V6V1dFeU1XaFVXbGxQZUdsVGFXTndaa1puU2pNd2EyNDFZVlZKUVhSa01EVkpXbmszZWpGelJHbFdUSFJVV0d4TVptVXZXbEZETkhCdWFrWjBjeXQwWXpFeWMxZzVhV2hKYlc1RGEyUXdWM1o2TTBOVVdtOTVRbE56WXpGVVpFSnJZamx0TUVNMWRIWm5NR1pSVURSUlowWXZla2d5VVc5YWJtNXlTVFV5ZFVGYU9FMXZiVmQwV1RKc2RETkVNR3RyY0ZJMk9YQm1Wa1JLTjNremRrNHZaWGRKUkVGUlFVST0="
     },
-    "ids:endpointDocumentation" : [ ],
-    "ids:endpointInformation" : [ ]
-  },
-  "ids:hasEndpoint" : [ ]
+    "ids:version": "7.1.0",
+    "ids:description": [
+        {
+            "@value": "IDS Connector B with static example resources",
+            "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+    ],
+    "ids:securityProfile": {
+        "@id": "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE"
+    },
+    "ids:maintainer": {
+        "@id": "https://sovity.de/"
+    },
+    "ids:curator": {
+        "@id": "https://sovity.de/"
+    },
+    "ids:inboundModelVersion": [
+        "4.2.6",
+        "4.2.7",
+        "4.2.0",
+        "4.2.1",
+        "4.1.2",
+        "4.0.0",
+        "4.1.0",
+        "4.2.4",
+        "4.2.5",
+        "4.2.2",
+        "4.2.3"
+    ],
+    "ids:outboundModelVersion": "4.2.7",
+    "ids:title": [
+        {
+            "@value": "Dataspace Connector",
+            "@type": "http://www.w3.org/2001/XMLSchema#string"
+        }
+    ],
+    "ids:hasDefaultEndpoint": {
+        "@type": "ids:ConnectorEndpoint",
+        "@id": "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
+        "ids:accessURL": {
+            "@id": "https://connectorb:8081/api/ids/data"
+        }
+    }
 }
 ```
 
 ### 4.2. Request Data from Available Connectors
 ***Connector A***  
 Connector A offers an exemplary data artifact with weather warnings from the DWD. Obtain the resource catalog @id from the Self-Description requested in 4.1
-> https://connectora:8080/api/catalogs/2cd59c94-54e4-4979-9842-36ee45dd354f
+> https://connectora:8080/api/catalogs/eb72752d-23ed-4ff8-b679-bd4c4b950b97
 
 Request the data sets from connector A using those of the following protocols you support:
   * Multipart: currently supported by connector A
   * IDSCP2: currently supported by connector A - still work in progress
   * IDS-REST: not yet supported by connector A
 
-Validate that you receive as data the following URL which can be used to obtain the corresponding DWD weather data:
-https://maps.dwd.de/geoserver/dwd/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=dwd%3AAutowarn_Analyse&maxFeatures=50&outputFormat=application%2Fjson
+Follow the provided Postman collection `Guide for Preparing and Validating the Preconfigured Setup/Validating Preconfigured Setup: Interaction between Connectors` to validate that you are able to receive the data offered by the Dataspace Connector acting as providert:
 
 ***Connector B***
 Connector B is currently not offering any data sets but only helping with validating the correct testbed setup as described in the [Guide for Preparing and Validating the Preconfigured Setup](./PreparingPreconfiguredSetup.md).
@@ -195,105 +213,109 @@ Request the self-description of the Broker.
 The response body should give code 200 and should be comparable to the following:
 ```json
 {
-  "@context" : {
-    "ids" : "https://w3id.org/idsa/core/",
-    "idsc" : "https://w3id.org/idsa/code/"
-  },
-  "@type" : "ids:Broker",
-  "@id" : "https://localhost/",
-  "ids:description" : [ {
-    "@value" : "A Broker with a graph persistence layer",
-    "@language" : "en"
-  } ],
-  "ids:title" : [ {
-    "@value" : "IDS Metadata Broker",
-    "@language" : "en"
-  } ],
-  "ids:maintainer" : {
-    "@id" : "https://www.iais.fraunhofer.de"
-  },
-  "ids:curator" : {
-    "@id" : "https://www.iais.fraunhofer.de"
-  },
-  "ids:inboundModelVersion" : [ "4.0.3" ],
-  "ids:outboundModelVersion" : "4.0.3",
-  "ids:resourceCatalog" : [ {
-    "@type" : "ids:ResourceCatalog",
-    "@id" : "https://w3id.org/idsa/autogen/resourceCatalog/b76c559b-359d-4e2f-bb2e-cd2692ed985e",
-    "ids:offeredResource" : [ {
-      "@type" : "ids:DataResource",
-      "@id" : "https://w3id.org/idsa/autogen/dataResource/41ea3278-89ed-4e5a-800c-836f01731dbd",
-      "ids:description" : [ ],
-      "ids:language" : [ ],
-      "ids:title" : [ ],
-      "ids:resourceEndpoint" : [ ],
-      "ids:contractOffer" : [ ],
-      "ids:sample" : [ ],
-      "ids:contentPart" : [ ],
-      "ids:representation" : [ {
-        "@type" : "ids:DataRepresentation",
-        "@id" : "https://w3id.org/idsa/autogen/dataRepresentation/44c079d3-0e53-40d3-8634-0a15f424e459",
-        "ids:description" : [ ],
-        "ids:title" : [ ],
-        "ids:instance" : [ {
-          "@type" : "ids:Artifact",
-          "@id" : "https://localhost/connectors/"
-        } ]
-      } ],
-      "ids:defaultRepresentation" : [ ],
-      "ids:resourcePart" : [ ],
-      "ids:theme" : [ ],
-      "ids:keyword" : [ ],
-      "ids:temporalCoverage" : [ ],
-      "ids:spatialCoverage" : [ ]
-    } ],
-    "ids:requestedResource" : [ ]
-  } ],
-  "ids:hasAgent" : [ ],
-  "ids:securityProfile" : {
-    "@id" : "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE"
-  },
-  "ids:extendedGuarantee" : [ ],
-  "ids:hasEndpoint" : [ {
-    "@type" : "ids:ConnectorEndpoint",
-    "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/2d4cf2c8-2023-4e5e-8f3e-0906ba278295",
-    "ids:path" : "/infrastructure",
-    "ids:accessURL" : {
-      "@id" : "https://localhost/infrastructure"
+    "@context": {
+        "ids": "https://w3id.org/idsa/core/",
+        "idsc": "https://w3id.org/idsa/code/"
     },
-    "ids:endpointDocumentation" : [ {
-      "@id" : "https://app.swaggerhub.com/apis/idsa/IDS-Broker/1.3.1#/Multipart%20Interactions/post_infrastructure"
-    } ],
-    "ids:endpointInformation" : [ {
-      "@value" : "This endpoint provides IDS Connector and IDS Resource registration and search capabilities at the IDS Metadata Broker.",
-      "@language" : "en"
-    }, {
-      "@value" : "Dieser Endpunkt ermÃ¶glicht die Registrierung von und das Suchen nach IDS Connectoren und IDS Ressourcen am IDS Metadata Broker.",
-      "@language" : "de"
-    } ]
-  } ],
-  "ids:hasDefaultEndpoint" : {
-    "@type" : "ids:ConnectorEndpoint",
-    "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/ac1ce4c6-6e8a-490d-bf7d-2ae560fd7ba5",
-    "ids:path" : "/",
-    "ids:accessURL" : {
-      "@id" : "https://localhost/"
+    "@type": "ids:Broker",
+    "@id": "https://localhost/",
+    "ids:description": [
+        {
+            "@value": "A Broker with a graph persistence layer",
+            "@language": "en"
+        }
+    ],
+    "ids:resourceCatalog": [
+        {
+            "@type": "ids:ResourceCatalog",
+            "@id": "https://w3id.org/idsa/autogen/resourceCatalog/fce5bdd4-cf42-44ff-8c67-dbef3fb138e0",
+            "ids:offeredResource": [
+                {
+                    "@type": "ids:DataResource",
+                    "@id": "https://w3id.org/idsa/autogen/dataResource/2864e71b-f5da-4d19-bd67-72748370302a",
+                    "ids:representation": [
+                        {
+                            "@type": "ids:DataRepresentation",
+                            "@id": "https://w3id.org/idsa/autogen/dataRepresentation/bfe7fd72-e393-4e77-8106-8c0dcef686de",
+                            "ids:instance": [
+                                {
+                                    "@type": "ids:Artifact",
+                                    "@id": "https://localhost/connectors/"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "ids:securityProfile": {
+        "@id": "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE"
     },
-    "ids:endpointDocumentation" : [ ],
-    "ids:endpointInformation" : [ {
-      "@value" : "Dieser Endpunkt liefert eine Selbstbeschreibung dieses IDS Connectors",
-      "@language" : "de"
-    }, {
-      "@value" : "Endpoint providing a self-description of this connector",
-      "@language" : "en"
-    } ]
-  },
-  "ids:connectorCatalog" : [ ]
+    "ids:maintainer": {
+        "@id": "https://www.iais.fraunhofer.de"
+    },
+    "ids:curator": {
+        "@id": "https://www.iais.fraunhofer.de"
+    },
+    "ids:inboundModelVersion": [
+        "4.0.3"
+    ],
+    "ids:outboundModelVersion": "4.0.3",
+    "ids:title": [
+        {
+            "@value": "IDS Metadata Broker",
+            "@language": "en"
+        }
+    ],
+    "ids:hasDefaultEndpoint": {
+        "@type": "ids:ConnectorEndpoint",
+        "@id": "https://w3id.org/idsa/autogen/connectorEndpoint/e12ab294-8f14-41e9-be1d-2958db4e5263",
+        "ids:path": "/",
+        "ids:accessURL": {
+            "@id": "https://localhost/"
+        },
+        "ids:endpointInformation": [
+            {
+                "@value": "Dieser Endpunkt liefert eine Selbstbeschreibung dieses IDS Connectors",
+                "@language": "de"
+            },
+            {
+                "@value": "Endpoint providing a self-description of this connector",
+                "@language": "en"
+            }
+        ]
+    },
+    "ids:hasEndpoint": [
+        {
+            "@type": "ids:ConnectorEndpoint",
+            "@id": "https://w3id.org/idsa/autogen/connectorEndpoint/0e2dc9c3-2a06-4318-bcb8-f83613eb4800",
+            "ids:path": "/infrastructure",
+            "ids:endpointDocumentation": [
+                {
+                    "@id": "https://app.swaggerhub.com/apis/idsa/IDS-Broker/1.3.1#/Multipart%20Interactions/post_infrastructure"
+                }
+            ],
+            "ids:accessURL": {
+                "@id": "https://localhost/infrastructure"
+            },
+            "ids:endpointInformation": [
+                {
+                    "@value": "This endpoint provides IDS Connector and IDS Resource registration and search capabilities at the IDS Metadata Broker.",
+                    "@language": "en"
+                },
+                {
+                    "@value": "Dieser Endpunkt ermÃ¶glicht die Registrierung von und das Suchen nach IDS Connectoren und IDS Ressourcen am IDS Metadata Broker.",
+                    "@language": "de"
+                }
+            ]
+        }
+    ]
 }
 ```
 
 ### 5.2. Query the MetaData Broker for Available Connectors in the Testbed
-The MetaData Broker can be reached at https://localhost[:443] and is aware of the self-descriptions of connector A and B.
+The MetaData Broker can be reached at https://localhost[:444] and is aware of the self-descriptions of connector A and B.
 
 Query the MetaData Broker for all available datasets using those of the following protocols you support:
   * Multipart: currently supported by the MetaData Broker
@@ -303,115 +325,160 @@ Query the MetaData Broker for all available datasets using those of the followin
 Validate that you received the following list of connectors:
 ```json
 {
-  "@graph" : [ {
-    "@id" : "https://localhost/connectors/",
-    "@type" : "ids:ConnectorCatalog",
-    "listedConnector" : [ "https://localhost/connectors/2129657531", "https://localhost/connectors/2129657530" ]
-  }, {
-    "@id" : "https://localhost/connectors/2129657530",
-    "@type" : "ids:BaseConnector",
-    "sameAs" : "https://connector_A",
-    "curator" : "https://www.isst.fraunhofer.de/",
-    "description" : "IDS Connector A with static example resources",
-    "hasDefaultEndpoint" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
-    "inboundModelVersion" : [ "4.2.0", "4.0.0", "4.1.0", "4.1.2" ],
-    "maintainer" : "https://www.isst.fraunhofer.de/",
-    "outboundModelVersion" : "4.2.0",
-    "publicKey" : "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
-    "resourceCatalog" : "https://localhost/connectors/2129657530/-733289566",
-    "securityProfile" : "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE",
-    "title" : "Dataspace Connector",
-    "version" : "6.2.0"
-  }, {
-    "@id" : "https://localhost/connectors/2129657530/-733289566",
-    "@type" : "ids:ResourceCatalog",
-    "sameAs" : "https://localhost:8080/api/catalogs/2cd59c94-54e4-4979-9842-36ee45dd354f"
-  }, {
-    "@id" : "https://localhost/connectors/2129657531",
-    "@type" : "ids:BaseConnector",
-    "sameAs" : "https://connector_B",
-    "curator" : "https://www.isst.fraunhofer.de/",
-    "description" : "IDS Connector B with static example resources",
-    "hasDefaultEndpoint" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
-    "inboundModelVersion" : [ "4.2.0", "4.1.0", "4.1.2", "4.0.0" ],
-    "maintainer" : "https://www.isst.fraunhofer.de/",
-    "outboundModelVersion" : "4.2.0",
-    "publicKey" : "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
-    "securityProfile" : "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE",
-    "title" : "Dataspace Connector",
-    "version" : "6.2.0"
-  }, {
-    "@id" : "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
-    "@type" : "ids:ConnectorEndpoint",
-    "accessURL" : [ "https://connectorb:8081/api/ids/data", "https://connectora:8080/api/ids/data" ]
-  }, {
-    "@id" : "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
-    "@type" : "ids:PublicKey",
-    "keyType" : "https://w3id.org/idsa/code/RSA",
-    "keyValue" : "VkZWc1NsRnJiSEZSVlRWRFdqSjBlR0ZIZEhCU2Vtd3pUVVZLUWxWVlZrZFJWVVpRVVRCR1VrOUZSazVUVld4RFVUSmtURkV3UmxKU1ZVWXhaSHBhZEZKdVNtdGFiWGhaVjJ4U1Mxb3dXbEJSVkZaNllsVlNXVkY2UVRWVk1qRjNVMnhrZGxJelFqVlNWa3BoVkd0V05VMTZSbmRUTWxKNlZXdGtiMVpIYkhkVmFra3pZV3BzY0dOdE1YUmpWMnh2Wkdwa2JsTlhaRFpSTWpVMFRtMTBTbFZyTlVoVFZFb3hUVWM1UjFWVVZrZGFNMXBRVFZob05Gb3pjR3BoVjJoclkwVlpkMUV5YUd4VU1sazFVMVUxYm1GWVRsRmhNMFV4WVVkdk5GRlhWWFpTUm14WllUTmFjV0ZHUlRKWmVscG9ZWGs1WVZkWFduRk5SVFYzWTFoc1JsVkhUa3RPVlRGTlZXMHhXbEl5VmpSVVYwWk9WMjB4VlZsdVJrVlRibHBMWWtSV1MxSjZUWEpaYTFWNlYxZEZlVTFYYUZWWGJHeFFaVWRzVkdGWFRuZGFhMXB1VTJwTmQyRXlOREZaVmxaS1VWaFNhMDFFVmtwWGJtc3paV3BHZWxKSGJGZFVTRkpWVjBkNFRWcHRWWFpYYkVaRVRraENkV0ZyV2pCamVYUXdXWHBGZVdNeFp6VmhWMmhLWWxjMVJHRXlVWGRXTTFvMlRUQk9WVmR0T1RWUmJFNTZXWHBHVlZwRlNuSlphbXgwVFVWTk1XUklXbTVOUjFwU1ZVUlNVbG93V1habGEyZDVWVmM1WVdKdE5YbFRWRlY1WkZWR1lVOUZNWFppVm1Rd1YxUktjMlJFVGtWTlIzUnlZMFpKTWs5WVFtMVdhMUpMVGpOcmVtUnJOSFphV0dSS1VrVkdVbEZWU1QwPQ=="
-  } ],
-  "@context" : {
-    "accessURL" : {
-      "@id" : "https://w3id.org/idsa/core/accessURL",
-      "@type" : "@id"
-    },
-    "sameAs" : {
-      "@id" : "http://www.w3.org/2002/07/owl#sameAs",
-      "@type" : "@id"
-    },
-    "description" : {
-      "@id" : "https://w3id.org/idsa/core/description"
-    },
-    "hasDefaultEndpoint" : {
-      "@id" : "https://w3id.org/idsa/core/hasDefaultEndpoint",
-      "@type" : "@id"
-    },
-    "publicKey" : {
-      "@id" : "https://w3id.org/idsa/core/publicKey",
-      "@type" : "@id"
-    },
-    "curator" : {
-      "@id" : "https://w3id.org/idsa/core/curator",
-      "@type" : "@id"
-    },
-    "inboundModelVersion" : {
-      "@id" : "https://w3id.org/idsa/core/inboundModelVersion"
-    },
-    "title" : {
-      "@id" : "https://w3id.org/idsa/core/title"
-    },
-    "outboundModelVersion" : {
-      "@id" : "https://w3id.org/idsa/core/outboundModelVersion"
-    },
-    "securityProfile" : {
-      "@id" : "https://w3id.org/idsa/core/securityProfile",
-      "@type" : "@id"
-    },
-    "maintainer" : {
-      "@id" : "https://w3id.org/idsa/core/maintainer",
-      "@type" : "@id"
-    },
-    "resourceCatalog" : {
-      "@id" : "https://w3id.org/idsa/core/resourceCatalog",
-      "@type" : "@id"
-    },
-    "version" : {
-      "@id" : "https://w3id.org/idsa/core/version"
-    },
-    "listedConnector" : {
-      "@id" : "https://w3id.org/idsa/core/listedConnector",
-      "@type" : "@id"
-    },
-    "keyValue" : {
-      "@id" : "https://w3id.org/idsa/core/keyValue"
-    },
-    "keyType" : {
-      "@id" : "https://w3id.org/idsa/core/keyType",
-      "@type" : "@id"
-    },
-    "owl" : "http://www.w3.org/2002/07/owl#",
-    "ids" : "https://w3id.org/idsa/core/"
-  }
+    "@graph": [
+        {
+            "@id": "https://localhost/connectors/",
+            "@type": "ids:ConnectorCatalog",
+            "listedConnector": [
+                "https://localhost/connectors/2129657531",
+                "https://localhost/connectors/2129657530"
+            ]
+        },
+        {
+            "@id": "https://localhost/connectors/2129657530",
+            "@type": "ids:BaseConnector",
+            "sameAs": "https://connector_A",
+            "curator": "https://sovity.de/",
+            "description": "IDS Connector A with static example resources",
+            "hasDefaultEndpoint": "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
+            "inboundModelVersion": [
+                "4.2.4",
+                "4.2.6",
+                "4.2.0",
+                "4.2.3",
+                "4.0.0",
+                "4.2.2",
+                "4.1.0",
+                "4.2.5",
+                "4.2.7",
+                "4.1.2",
+                "4.2.1"
+            ],
+            "maintainer": "https://sovity.de/",
+            "outboundModelVersion": "4.2.7",
+            "publicKey": "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
+            "resourceCatalog": "https://localhost/connectors/2129657530/277846396",
+            "securityProfile": "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE",
+            "title": "Dataspace Connector",
+            "version": "7.1.0"
+        },
+        {
+            "@id": "https://localhost/connectors/2129657530/277846396",
+            "@type": "ids:ResourceCatalog",
+            "sameAs": "https://localhost:8080/api/catalogs/eb72752d-23ed-4ff8-b679-bd4c4b950b97"
+        },
+        {
+            "@id": "https://localhost/connectors/2129657531",
+            "@type": "ids:BaseConnector",
+            "sameAs": "https://connector_B",
+            "curator": "https://sovity.de/",
+            "description": "IDS Connector B with static example resources",
+            "hasDefaultEndpoint": "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
+            "inboundModelVersion": [
+                "4.2.4",
+                "4.2.7",
+                "4.2.6",
+                "4.2.0",
+                "4.2.3",
+                "4.2.2",
+                "4.1.0",
+                "4.2.5",
+                "4.1.2",
+                "4.0.0",
+                "4.2.1"
+            ],
+            "maintainer": "https://sovity.de/",
+            "outboundModelVersion": "4.2.7",
+            "publicKey": "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
+            "securityProfile": "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE",
+            "title": "Dataspace Connector",
+            "version": "7.1.0"
+        },
+        {
+            "@id": "https://w3id.org/idsa/autogen/connectorEndpoint/e5e2ab04-633a-44b9-87d9-a097ae6da3cf",
+            "@type": "ids:ConnectorEndpoint",
+            "accessURL": [
+                "https://connectorb:8081/api/ids/data",
+                "https://connectora:8080/api/ids/data"
+            ]
+        },
+        {
+            "@id": "https://w3id.org/idsa/autogen/publicKey/78eb73a3-3a2a-4626-a0ff-631ab50a00f9",
+            "@type": "ids:PublicKey",
+            "keyType": "https://w3id.org/idsa/code/RSA",
+            "keyValue": "VkZWc1NsRnJiSEZSVlRWRFdqSjBlR0ZIZEhCU2Vtd3pUVVZLUWxWVlZrZFJWVVpRVVRCR1VrOUZSazVUVld4RFVUSmtURkV3UmxKU1ZVWXhaSHBhZEZKdVNtdGFiWGhaVjJ4U1Mxb3dXbEJSVkZaNllsVlNXVkY2UVRWVk1qRjNVMnhrZGxJelFqVlNWa3BoVkd0V05VMTZSbmRUTWxKNlZXdGtiMVpIYkhkVmFra3pZV3BzY0dOdE1YUmpWMnh2Wkdwa2JsTlhaRFpSTWpVMFRtMTBTbFZyTlVoVFZFb3hUVWM1UjFWVVZrZGFNMXBRVFZob05Gb3pjR3BoVjJoclkwVlpkMUV5YUd4VU1sazFVMVUxYm1GWVRsRmhNMFV4WVVkdk5GRlhWWFpTUm14WllUTmFjV0ZHUlRKWmVscG9ZWGs1WVZkWFduRk5SVFYzWTFoc1JsVkhUa3RPVlRGTlZXMHhXbEl5VmpSVVYwWk9WMjB4VlZsdVJrVlRibHBMWWtSV1MxSjZUWEpaYTFWNlYxZEZlVTFYYUZWWGJHeFFaVWRzVkdGWFRuZGFhMXB1VTJwTmQyRXlOREZaVmxaS1VWaFNhMDFFVmtwWGJtc3paV3BHZWxKSGJGZFVTRkpWVjBkNFRWcHRWWFpYYkVaRVRraENkV0ZyV2pCamVYUXdXWHBGZVdNeFp6VmhWMmhLWWxjMVJHRXlVWGRXTTFvMlRUQk9WVmR0T1RWUmJFNTZXWHBHVlZwRlNuSlphbXgwVFVWTk1XUklXbTVOUjFwU1ZVUlNVbG93V1habGEyZDVWVmM1WVdKdE5YbFRWRlY1WkZWR1lVOUZNWFppVm1Rd1YxUktjMlJFVGtWTlIzUnlZMFpKTWs5WVFtMVdhMUpMVGpOcmVtUnJOSFphV0dSS1VrVkdVbEZWU1QwPQ=="
+        },
+        {
+            "@id": "https://w3id.org/idsa/code/BASE_SECURITY_PROFILE",
+            "@type": "ids:SecurityProfile"
+        },
+        {
+            "@id": "https://w3id.org/idsa/code/RSA",
+            "@type": "ids:KeyType"
+        }
+    ],
+    "@context": {
+        "accessURL": {
+            "@id": "https://w3id.org/idsa/core/accessURL",
+            "@type": "@id"
+        },
+        "maintainer": {
+            "@id": "https://w3id.org/idsa/core/maintainer",
+            "@type": "@id"
+        },
+        "inboundModelVersion": {
+            "@id": "https://w3id.org/idsa/core/inboundModelVersion"
+        },
+        "description": {
+            "@id": "https://w3id.org/idsa/core/description"
+        },
+        "hasDefaultEndpoint": {
+            "@id": "https://w3id.org/idsa/core/hasDefaultEndpoint",
+            "@type": "@id"
+        },
+        "publicKey": {
+            "@id": "https://w3id.org/idsa/core/publicKey",
+            "@type": "@id"
+        },
+        "sameAs": {
+            "@id": "http://www.w3.org/2002/07/owl#sameAs",
+            "@type": "@id"
+        },
+        "outboundModelVersion": {
+            "@id": "https://w3id.org/idsa/core/outboundModelVersion"
+        },
+        "version": {
+            "@id": "https://w3id.org/idsa/core/version"
+        },
+        "title": {
+            "@id": "https://w3id.org/idsa/core/title"
+        },
+        "curator": {
+            "@id": "https://w3id.org/idsa/core/curator",
+            "@type": "@id"
+        },
+        "securityProfile": {
+            "@id": "https://w3id.org/idsa/core/securityProfile",
+            "@type": "@id"
+        },
+        "resourceCatalog": {
+            "@id": "https://w3id.org/idsa/core/resourceCatalog",
+            "@type": "@id"
+        },
+        "listedConnector": {
+            "@id": "https://w3id.org/idsa/core/listedConnector",
+            "@type": "@id"
+        },
+        "keyValue": {
+            "@id": "https://w3id.org/idsa/core/keyValue"
+        },
+        "keyType": {
+            "@id": "https://w3id.org/idsa/core/keyType",
+            "@type": "@id"
+        },
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "ids": "https://w3id.org/idsa/core/"
+    }
 }
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - local
 
   broker-core:
-    image: idstestbed/broker-core:4.2.8
+    image: idstestbed/broker-core:5.0.0
     container_name: broker-core
     volumes:
       - ./MetadataBroker/isstbroker-keystore.jks:/etc/cert/isstbroker-keystore.jks


### PR DESCRIPTION
It has been changed the `InstallationGuide.md` file :
-	Fix issue #93 now the IDS-testbed uses `DAPS/register_connector.sh` file to add clients to the DAPS’s list of clients. 
-	**Index** included at the `InstallationGuide.md` file.
-	Revision and update of the installation guide document to fix no conformities with the actual status of the IDS-testbed.
-	Version 4.2.8 of the MDB has some errors with the local broker-core image. Updated MDB from version 4.2.8 to version 5.0.0

Change to the `README.md` file regarding new version of MDB (v5.0.0).
Change in the `docker-compose.yml` to use version 5.0.0 of the MDB for the preconfigured IDS-testbed deployment.
