### PR TITLE
Documentation update and fix issue #118

### DIFF
--- a/DAPS/register_connector.sh
+++ b/DAPS/register_connector.sh
@@ -14,7 +14,13 @@ CLIENT_CERT="keys/$CLIENT_NAME.cert"
 
 SKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Subject Key Identifier" | tail -n 1 | tr -d ' ')"
 AKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Authority Key Identifier" | tail -n 1 | tr -d ' ')"
-CLIENT_ID="$SKI:$AKI"
+SUB='keyid'
+
+if [ "$AKI" = *"$SUB"* ];then
+   CLIENT_ID="$SKI:$AKI"
+else
+   CLIENT_ID="$SKI:keyid:$AKI"
+fi
 
 CLIENT_CERT_SHA="$(openssl x509 -in "$CLIENT_CERT" -noout -sha256 -fingerprint | tr '[:upper:]' '[:lower:]' | tr -d : | sed 's/.*=//')"
 

--- a/DAPS/register_connector.sh
+++ b/DAPS/register_connector.sh
@@ -16,11 +16,18 @@ SKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Subj
 AKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Authority Key Identifier" | tail -n 1 | tr -d ' ')"
 SUB='keyid'
 
-if [ "$AKI" = *"$SUB"* ];then
-   CLIENT_ID="$SKI:$AKI"
-else
-   CLIENT_ID="$SKI:keyid:$AKI"
-fi
+contains() {
+    string="$AKI"
+    substring="$SUB"
+    if test "${string#*$substring}" != "$string"
+    then
+        CLIENT_ID="$SKI:$AKI"    # $substring is in $string
+    else
+        CLIENT_ID="$SKI:keyid:$AKI"    # $substring is not in $string
+    fi
+}
+
+contains "$AKI" "$SUB"
 
 CLIENT_CERT_SHA="$(openssl x509 -in "$CLIENT_CERT" -noout -sha256 -fingerprint | tr '[:upper:]' '[:lower:]' | tr -d : | sed 's/.*=//')"
 

--- a/InstallationGuide.md
+++ b/InstallationGuide.md
@@ -571,6 +571,13 @@ For the IDS-testbed deployment it is configured at the `docker-compose.yml`. Her
 
 The server `server.ssl.key-store=file:///config/{TLS_FILENAME}.p12`, where `{TLS_FILENAME}` is to be replaced with the certificate created previously by the local CA. The Dataspace Connector expects the TLS certificate in `.p12` format.
 
+**Note** Make sure the created certificates have the correct permissions. For the Dataspace Connector this `.p12` format certificate must be configured with read and write rights for the `user permissions` and `group permissions`. 
+The file permissions can be viewed and changed using the following commands:
+```
+ls -l
+chmod 664 {TLS_FILENAME.p12}
+````
+
 ## Changes to the config.json file
 Use nano or your most favourite editor
 ```


### PR DESCRIPTION
- Added to the `Installation Guide` how to view and change the DSC required certificates permissions.
- Fix issue #118. 
  It was found that using version OpenSSL 3.0.2 15 Mar 2022 (Library: OpenSSL 3.0.2 15 Mar 2022) does not generate correctly the `client_id` value at the `DAPS/config/clients.yml` list (missing `keyid` value between SKI and AKI).
It has been modified `register_connector.sh` script for the correct registration of certificates at the DAPS's client list. 
Now, it has been checked that it is possible to use different versions of OpenSSL to register at the DAPS the certificates required during the `Installation Guide` document.