### PR TITLE
Add new line if not present in the clients.yml file

### DIFF
--- a/DAPS/register_connector.sh
+++ b/DAPS/register_connector.sh
@@ -31,7 +31,8 @@ contains "$AKI" "$SUB"
 
 CLIENT_CERT_SHA="$(openssl x509 -in "$CLIENT_CERT" -noout -sha256 -fingerprint | tr '[:upper:]' '[:lower:]' | tr -d : | sed 's/.*=//')"
 
-cat >> config/clients.yml <<EOF
+cat >>config/clients.yml <<EOF
+$([ "$(tail -c 1 config/clients.yml)" != $'\n' ] && echo)
 - client_id: $CLIENT_ID
   client_name: $CLIENT_NAME
   grant_types: client_credentials

--- a/DAPS/register_connector.sh
+++ b/DAPS/register_connector.sh
@@ -1,60 +1,59 @@
 #!/bin/sh
 
-if [ ! $# -ge 1 ] || [ ! $# -le 3 ]; then
+# Validate the number of arguments (1 to 3)
+if [ "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
   echo "Usage: $0 NAME (SECURITY_PROFILE) (CERTFILE)"
   exit 1
 fi
 
 CLIENT_NAME=$1
-
 CLIENT_SECURITY_PROFILE=$2
 [ -z "$CLIENT_SECURITY_PROFILE" ] && CLIENT_SECURITY_PROFILE="idsc:BASE_SECURITY_PROFILE"
-
 CLIENT_CERT="keys/$CLIENT_NAME.cert"
 
-SKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Subject Key Identifier" | tail -n 1 | tr -d ' ')"
-AKI="$(openssl x509 -in "keys/${CLIENT_NAME}.cert" -noout -text | grep -A1 "Authority Key Identifier" | tail -n 1 | tr -d ' ')"
+# Extract SKI and AKI using openssl
+SKI="$(openssl x509 -in "$CLIENT_CERT" -noout -text | grep -A1 "Subject Key Identifier" | tail -n 1 | tr -d ' ')"
+AKI="$(openssl x509 -in "$CLIENT_CERT" -noout -text | grep -A1 "Authority Key Identifier" | tail -n 1 | tr -d ' ')"
 SUB='keyid'
 
-contains() {
-  string="$AKI"
-  substring="$SUB"
-  if test "${string#*$substring}" != "$string"; then
-    CLIENT_ID="$SKI:$AKI" # $substring is in $string
-  else
-    CLIENT_ID="$SKI:keyid:$AKI" # $substring is not in $string
-  fi
-}
-
-contains "$AKI" "$SUB"
+# Determine CLIENT_ID based on presence of 'keyid' in AKI
+if echo "$AKI" | grep -q "$SUB"; then
+  CLIENT_ID="$SKI:$AKI"
+else
+  CLIENT_ID="$SKI:keyid:$AKI"
+fi
 
 CLIENT_CERT_SHA="$(openssl x509 -in "$CLIENT_CERT" -noout -sha256 -fingerprint | tr '[:upper:]' '[:lower:]' | tr -d : | sed 's/.*=//')"
 
-# Check if client with the same ID or name already exists
-if grep -q "client_id: $CLIENT_ID" config/clients.yml || grep -q "client_name: $CLIENT_NAME" config/clients.yml; then
-  echo "Client with ID $CLIENT_ID or name $CLIENT_NAME already exists in config/clients.yml. Skipping addition."
+# Check if a client with the same client_id or client_name exists
+CLIENT_EXISTS=$(yq eval '.[] | select(.client_id == "'"$CLIENT_ID"'" or .client_name == "'"$CLIENT_NAME"'")' config/clients.yml)
+
+if [ -n "$CLIENT_EXISTS" ]; then
+  echo "Client with ID $CLIENT_ID or name $CLIENT_NAME already exists. Updating the existing entry."
+
+  # Update client_id, client_name, and transportCertsSha256 for the exact matching entry
+  yq eval -i '
+    map(
+      select(.client_id == "'"$CLIENT_ID"'" or .client_name == "'"$CLIENT_NAME"'") |= 
+      (.client_id = "'"$CLIENT_ID"'" | 
+       .client_name = "'"$CLIENT_NAME"'" | 
+       (.attributes[] | select(.key == "transportCertsSha256").value) = "'"$CLIENT_CERT_SHA"'")
+    )
+  ' config/clients.yml
+
+  echo "Client entry updated successfully."
   exit 0
 fi
 
-cat >>config/clients.yml <<EOF
-$([ "$(tail -c 1 config/clients.yml)" != $'\n' ] && echo)
-- client_id: $CLIENT_ID
-  client_name: $CLIENT_NAME
-  grant_types: client_credentials
-  token_endpoint_auth_method: private_key_jwt
-  scope: idsc:IDS_CONNECTOR_ATTRIBUTES_ALL
-  attributes:
-  - key: idsc
-    value: IDS_CONNECTOR_ATTRIBUTES_ALL
-  - key: securityProfile
-    value: $CLIENT_SECURITY_PROFILE
-  - key: referringConnector
-    value: http://${CLIENT_NAME}.demo
-  - key: "@type"
-    value: ids:DatPayload
-  - key: "@context"
-    value: https://w3id.org/idsa/contexts/context.jsonld
-  - key: transportCertsSha256
-    value: $CLIENT_CERT_SHA
-  import_certfile: $CLIENT_CERT
-EOF
+# If the client does not exist, append the new client entry
+echo "Adding new client entry to config/clients.yml."
+
+# Ensure the file ends with a newline
+if [ -n "$(tail -c 1 config/clients.yml)" ] && [ "$(tail -c 1 config/clients.yml)" != $'\n' ]; then
+  echo >>config/clients.yml
+fi
+
+# Append the new client entry
+yq eval -i '. += [{"client_id": "'"$CLIENT_ID"'", "client_name": "'"$CLIENT_NAME"'", "grant_types": "client_credentials", "token_endpoint_auth_method": "private_key_jwt", "scope": "idsc:IDS_CONNECTOR_ATTRIBUTES_ALL", "attributes": [{"key": "idsc", "value": "IDS_CONNECTOR_ATTRIBUTES_ALL"}, {"key": "securityProfile", "value": "'"$CLIENT_SECURITY_PROFILE"'"}, {"key": "referringConnector", "value": "http://'"${CLIENT_NAME}"'.demo"}, {"key": "@type", "value": "ids:DatPayload"}, {"key": "@context", "value": "https://w3id.org/idsa/contexts/context.jsonld"}, {"key": "transportCertsSha256", "value": "'"$CLIENT_CERT_SHA"'"}], "import_certfile": "'"$CLIENT_CERT"'"}]' config/clients.yml
+
+echo "Client entry added successfully."


### PR DESCRIPTION
~~Add newline before appending to config/clients.yml~~
~~This change ensures that a newline is added before appending new content to the config/clients.yml file. It addresses the following scenarios:~~
~~1. If the file already ends with a newline, no additional newline is added.~~
~~2. If the file doesn't end with a newline, a newline is inserted before the new content.~~
~~This modification improves the reliability of the configuration file generation process by preventing potential formatting issues or unintended merging of content.~~

## ~~EDIT~~
~~I added also a check for existing configuration in the clients.yml file based on the client_name and client_id to avoid duplicates~~

## EDIT 2

After careful consideration, I've decided to refactor and rewrite a significant portion of the code while maintaining the core logic. This refactoring was necessary to properly handle several edge cases that were not initially accounted for in the original implementation.

Unfortunately, due to the new manipulations performed by the code, I had to introduce a dependency:
- [yq](https://github.com/mikefarah/yq): A lightweight command-line YAML processor.

The code checks for the existence of a newline at the end of the file, but now in addition to the newline check, the code verifies if a client_id or client_name already exists in the file. If found, the existing entry is modified with the new data instead of adding a duplicate entry.

This enhancement allows for more robust handling of clients, preventing duplicates and ensuring that existing entries are properly updated when new information is available.

